### PR TITLE
Changing permissions of home directory

### DIFF
--- a/level2/Dockerfile
+++ b/level2/Dockerfile
@@ -46,6 +46,7 @@ RUN wget -q -P /opt http://www.fil.ion.ucl.ac.uk/spm/download/restricted/bids/sp
 
 # Make the spm12_run.sh script executable for NB_USER
 RUN chown -R $NB_USER:users /opt/spm12
+RUN chown -R $NB_USER:users /home/$NB_USER/*
 
 #----------------------------------------
 # Clear apt cache and other empty folders


### PR DESCRIPTION
As it stands, /home/jovyan/.matlab does not have appropriate permissions. See error below:


```
RuntimeError: Command:
/opt/spm12/run_spm12.sh /opt/mcr/v91/ script /home/jovyan/work/output/workingdir/l1analysis/_subject_id_sub-s358_task_stroop/le
vel1design/pyscript_level1design.m

Standard output:
------------------------------------------
Setting up environment variables
---
LD_LIBRARY_PATH is .:/opt/mcr/v91//runtime/glnxa64:/opt/mcr/v91//bin/glnxa64:/opt/mcr/v91//sys/os/glnxa64:/opt/mcr/v91//sys/ope
ngl/lib/glnxa64

Standard error:
Could not access preferences directory: '/home/jovyan/.matlab/mcr_v91/spm12_9342CB87155FCCCB38BD18FFCBC502A9'. System error: 'T
ried to obtain a lock on a directory without write permission: /home/jovyan/.matlab/mcr_v91/.deploy_lock.0'
Return code: 255
Interface MatlabCommand failed to run.
Interface Level1Design failed to run.
```